### PR TITLE
added fix for space after hostname when server has more that 1 ip

### DIFF
--- a/wg-install.sh
+++ b/wg-install.sh
@@ -43,7 +43,7 @@ if [ ! -f "$WG_CONFIG" ]; then
     GATEWAY_ADDRESS="${PRIVATE_SUBNET::-4}1"
 
     if [ "$SERVER_HOST" == "" ]; then
-        SERVER_HOST=$(hostname -I)
+        SERVER_HOST=$(hostname -i)
         if [ "$INTERACTIVE" == "yes" ]; then
             read -p "[i] Servers public IP address is $SERVER_HOST  Is that correct? [y/n]: " -e -i "y" CONFIRM
             if [ "$CONFIRM" == "n" ]; then


### PR DESCRIPTION
when server has more than 1 IP the hostname -I command replies
with all IPs separated with space.
The existing command will parse the space in the following lines
and also in the first line of the /etc/wireguard/wg0.conf file
which contains config for the following runs to generate the
new clients configs.